### PR TITLE
Return non 0 exit code on failure

### DIFF
--- a/examples/example1.ss
+++ b/examples/example1.ss
@@ -27,3 +27,4 @@
 
 (run-tests foo second-test first-test)
 
+(run-test-suites foo bar)

--- a/examples/example1.ss
+++ b/examples/example1.ss
@@ -16,7 +16,12 @@
       (assert-string=? (list->string y) "foo")
       (assert-char=? (car y) #\f))))
 
+(define-test-suite bar
+  (define-test third-test
+    (assert-equal? '(2 3) (cdr '(1 2 3)))))
+
 (run-test-suite foo)
+(run-test-suite bar)
 
 (run-test foo first-test)
 

--- a/examples/example2.ss
+++ b/examples/example2.ss
@@ -1,0 +1,16 @@
+(import
+  (rnrs)
+  (rough-draft unit-test)
+  (rough-draft console-test-runner))
+
+(define-test-suite foo
+  (define-test test-car
+    (assert-equal? 1 (car '(1 2 3)))))
+
+(define-test-suite bar
+  (define-test test-cdr
+    (assert-equal? '(2 3) (cdr '(1 2 3 42)))))
+
+(run-test-suite bar)
+
+(run-test-suites foo bar)

--- a/src/rough-draft/console-test-runner.ss
+++ b/src/rough-draft/console-test-runner.ss
@@ -123,7 +123,8 @@
     (lambda test-suites
       (let loop ([test-suites test-suites] [suite-info* '()])
         (if (null? test-suites)
-            (begin
+            (let ([failure-count  (map-+ suite-info-failure-count suite-info*)]
+                  [exception-count (map-+ suite-info-exception-count suite-info*)])
               (printf "Summary: Ran ~d test suite~:p with ~d test~:p and ~d assertion~:p, "
                 (length suite-info*)
                 (map-+ suite-info-test-count suite-info*)
@@ -131,10 +132,14 @@
               (printf "~d test~:p failed (~d error~:p, ~d exception~:p)~%"
                 (map-+ suite-info-failure-count suite-info*)
                 (map-+ suite-info-error-count suite-info*)
-                (map-+ suite-info-exception-count suite-info*)))
+                (map-+ suite-info-exception-count suite-info*))
+              (exit (+ failure-count exception-count)))
             (loop (cdr test-suites) (cons ($run-test-suite (car test-suites)) suite-info*))))))
 
   (define run-test-suite
     (lambda (test-suite)
-      ($run-test-suite test-suite)
-      (void))))
+      (let* ([res ($run-test-suite test-suite)]
+             [failure-count (suite-info-failure-count res)]
+             [error-count (suite-info-error-count res)]
+             [exit-code (+ failure-count error-count)])
+        (exit exit-code)))))


### PR DESCRIPTION
Hello,

I wonder if it would make sense to exit with code other than 0 when test suite fails?

I have made an experiment - this change exit with sum of tests that failed or error happened.
This will be 0 when all tests succeed.

Testing:
```sh
scheme --libdirs "../src" --program example2.ss
echo $?
```

When I work with tests e.g. in Scala using SBT that is what happens. I assume on other tech stacks this is similar.

@akeep WDYT?